### PR TITLE
[issue 57] Handle avro type errors

### DIFF
--- a/lib/rflow/connections/zmq_connection.rb
+++ b/lib/rflow/connections/zmq_connection.rb
@@ -81,8 +81,7 @@ class RFlow
         begin
           output_socket.send_msg(message.data_type_name.to_s, message.to_avro)
         rescue Exception => e
-          RFlow.logger.debug "Exception #{e.class}: #{e.message}, retrying send"
-          retry
+          RFlow.logger.error "Exception #{e.class}: #{e.message}, because: #{e.backtrace}"
         end
       end
 


### PR DESCRIPTION
Modify the send_message method so it logs any exception as an error.
Remove the retry to prevent an infinite loop.